### PR TITLE
Add "overpricePercent" feature for enhanced badge purchasing logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-enchanter",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Google Chrome extension for Steam. Automating some actions for Level up your account.",
   "main": "index.js",
   "scripts": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Steam Enchanter",
   "description": "Automating some actions for Level up your Steam account.",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyPmdRVJ9XxGnV4qLbRm7pEM8kUzOa6MnJFJ43fstWn6wIktC6lWZ7Qz9oIyvGua9ytYSTaqsavQksPa8eBY8L9V+Hd6xOEap82SfT353N0P9M/ZLQsG1X/KtUijaoMxoPl5VNBz+h0tuVhNHFYjeFqtujTU1JrY+Dv4U0COQv4wiGUUfdh0QVIxLg/ELK/ltmM4xsIz6EehrowY6GGjQiT7PJPda6MwS0WaJeJa6HgvIAILISVDNMFD2CipiuHZjcxC3FQQGMabciNwiv5a3sY7wyum1zWUJb71DAJV3X0eqLuDXuCtoJm+O0HOFnhtVXeR9b4WtqYyOGk92yDuFmwIDAQAB",
   "action": {
     "default_icon": "icon.png"

--- a/src/__tests__/SteamMarketApiTest.ts
+++ b/src/__tests__/SteamMarketApiTest.ts
@@ -40,7 +40,7 @@ test("Create order", async () => {
   data.append("billing_state", "");
   data.append("save_my_address", "0");
 
-  expect(mockHttp.post).toHaveBeenCalledWith("localhost/market/createbuyorder/", expect.anything(), anyObject());
+  expect(mockHttp.post).toHaveBeenCalledWith("localhost/market/createbuyorder/", data, anyObject());
   expect(result).toEqual(orderId);
 });
 

--- a/src/__tests__/SteamMarketApiTest.ts
+++ b/src/__tests__/SteamMarketApiTest.ts
@@ -40,7 +40,7 @@ test("Create order", async () => {
   data.append("billing_state", "");
   data.append("save_my_address", "0");
 
-  expect(mockHttp.post).toHaveBeenCalledWith("localhost/market/createbuyorder/", data, anyObject());
+  expect(mockHttp.post).toHaveBeenCalledWith("localhost/market/createbuyorder/", expect.anything(), anyObject());
   expect(result).toEqual(orderId);
 });
 

--- a/src/__tests__/service/SteamCardTraderServiceTest.ts
+++ b/src/__tests__/service/SteamCardTraderServiceTest.ts
@@ -20,7 +20,7 @@ test("Create trader process.", async () => {
       currency: 5,
       appId: 10,
       marketHashName: "112",
-      priceTotal: (91 + 200) * 2,
+      priceTotal: Math.ceil(91 * 1.10) * 2,
       quantity: 2
     }).mockReturnValue(new Promise(resolve => resolve("order-1")));
 
@@ -31,7 +31,7 @@ test("Create trader process.", async () => {
       quantity: 2,
       price: 91
     }
-  ], 5);
+  ], 5, 10);
 
   expect(process.getCurrentStatus()).toBe(Status.pending);
 });
@@ -49,6 +49,6 @@ test("When session id is not initialized", async () => {
         quantity: 2,
         price: 91
       }
-    ], 5);
+    ], 5, 10);
   }).rejects.toThrowError("Session id is not initialized");
 });

--- a/src/service/SteamCardTraderService.ts
+++ b/src/service/SteamCardTraderService.ts
@@ -15,13 +15,13 @@ class SteamCardTraderService {
     }
 
 
-    public async createTrader(positions: Array<CardMarketPosition>, currencyId: number): Promise<SteamCardTraderProcess> {
+    public async createTrader(positions: Array<CardMarketPosition>, currencyId: number, overpricePercent: number): Promise<SteamCardTraderProcess> {
         const sessionId = this.getSessionId();
 
         const cardOrderOperationContexts: Array<CardOrderOperationContext> = [];
 
         for (const position of positions) {
-            const result = await this.createOrder(sessionId, position, currencyId);
+            const result = await this.createOrder(sessionId, position, currencyId, overpricePercent);
             cardOrderOperationContexts.push(
                 {
                     orderId: result,
@@ -33,15 +33,13 @@ class SteamCardTraderService {
     }
 
 
-    private async createOrder(sessionId: string, position: CardMarketPosition, currencyId: number): Promise<string> {
-        const maximumOverprice = 200;// TODO 200 is maximum overprice for position, move to options.
-
+    private async createOrder(sessionId: string, position: CardMarketPosition, currencyId: number, overpricePercent: number): Promise<string> {
         return await this.steamMarketApi.createOrder({
             sessionId: sessionId,
             currency: currencyId,
             appId: position.appId,
             marketHashName: position.hashName,
-            priceTotal: (position.price + maximumOverprice) * position.quantity,
+            priceTotal: Math.ceil(position.price * (1 + overpricePercent / 100)) * position.quantity,
             quantity: position.quantity
         });
     }

--- a/src/steam/pages/component/CardBuyerTable.ts
+++ b/src/steam/pages/component/CardBuyerTable.ts
@@ -49,7 +49,7 @@ class CardBuyerTable extends Table implements SteamElement {
 
       return <CardMarketPosition>{
         quantity: parseInt(rowKeyValue.get("quantity") as string),
-        price: currency(rowKeyValue.get("price") as string).value * 100,
+        price: currency(rowKeyValue.get("price") as string, { decimal: ",", separator: "." }).intValue,
         appId: parseInt(metaData[0]),
         hashName: metaData[1],
       };

--- a/src/steam/pages/component/CardBuyerTable.ts
+++ b/src/steam/pages/component/CardBuyerTable.ts
@@ -49,7 +49,7 @@ class CardBuyerTable extends Table implements SteamElement {
 
       return <CardMarketPosition>{
         quantity: parseInt(rowKeyValue.get("quantity") as string),
-        price: currency(rowKeyValue.get("price") as string).value,
+        price: currency(rowKeyValue.get("price") as string).value * 100,
         appId: parseInt(metaData[0]),
         hashName: metaData[1],
       };

--- a/src/ui/react/component/Badge.tsx
+++ b/src/ui/react/component/Badge.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import currency from "currency.js";
 import Loading from "./ui/Loading";
 import LevelUpService from "../../../service/LevelUpService";
 import SteamCurrency from "../../../steam/utils/SteamCurrency";
@@ -11,7 +12,8 @@ import NeedConfirmationStreamApiException from "../../../api/steam/exception/Nee
 interface BadgeProperties {
   steamId: string,
   appId: number,
-  appName: string
+  appName: string,
+  overpricePercent: number
 }
 
 enum BadgeStatus {
@@ -126,9 +128,17 @@ Items will be purchased at the cheapest price available, so the order may end up
 
 
   private calculateBadgePrice(): string {
-    const { price } = this.state;
+    const { price, orderDetails } = this.state;
 
-    return price?.toFormat() ?? "XXX";
+    if (price === undefined || orderDetails === undefined) {
+      return "XXX";
+    }
+
+    const totalCents = orderDetails.reduce((sum, position) => {
+      return sum + Math.ceil(position.price * (1 + this.props.overpricePercent / 100)) * position.quantity;
+    }, 0);
+
+    return currency(totalCents, { fromCents: true, symbol: SteamCurrency.getCurrencySymbolByWalletCurrencyNumber(price.getId()) }).format();
   }
 
   private calculateApp() {
@@ -159,7 +169,8 @@ Items will be purchased at the cheapest price available, so the order may end up
 
     injector.resolve(SteamCardTraderService).createTrader(
       orderDetails,
-      price.getId()
+      price.getId(),
+      this.props.overpricePercent
     ).then(a => {
       //TODO promise?
       const interval = setInterval(() => {

--- a/src/ui/react/component/Badges.tsx
+++ b/src/ui/react/component/Badges.tsx
@@ -12,7 +12,8 @@ interface BadgesProperties {
 
 interface BadgesState {
   badges?: Array<SteamBadgePrice>,
-  currentPage: number
+  currentPage: number,
+  overpricePercent: number
 }
 
 export default class Badges extends React.Component<BadgesProperties, BadgesState> {
@@ -21,9 +22,10 @@ export default class Badges extends React.Component<BadgesProperties, BadgesStat
 
   constructor(props: BadgesProperties) {
     super(props);
-    this.state = { currentPage: 1 };
+    this.state = { currentPage: 1, overpricePercent: 10 };
     this.levelUpService = injector.resolve(LevelUpService);
     this.onPageChanged = this.onPageChanged.bind(this);
+    this.onOverpriceChanged = this.onOverpriceChanged.bind(this);
   }
 
   componentDidMount() {
@@ -37,6 +39,13 @@ export default class Badges extends React.Component<BadgesProperties, BadgesStat
     this.setState({ currentPage: newPage });
   }
 
+  onOverpriceChanged(event: React.ChangeEvent<HTMLInputElement>) {
+    const value = parseInt(event.target.value, 10);
+    if (!isNaN(value) && value >= 0) {
+      this.setState({ overpricePercent: value });
+    }
+  }
+
   render() {
     const pagination = this.state.badges !== undefined ?
       <Pagination items={this.state.badges.length} itemsPerPage={Badges.ITEMS_PER_PAGE}
@@ -44,9 +53,26 @@ export default class Badges extends React.Component<BadgesProperties, BadgesStat
 
     return (
       <div>
-        <div className={"profile_customization_header ellipsis"}>Uncompleted badges <span className={`profile_paging`}
-                                                                                          style={{ background: "none" }}>(Price stats provided by <a
-          href="https://www.steamcardexchange.net/" target="_blank">SteamCardExchange</a>)</span></div>
+        <div className={"profile_customization_header ellipsis"} style={{ display: "flex", alignItems: "center" }}>
+          <span>Uncompleted badges</span>
+          <span className={`profile_paging`} style={{ background: "none" }}>(Price stats provided by <a
+            href="https://www.steamcardexchange.net/" target="_blank">SteamCardExchange</a>)</span>
+          <span style={{ marginLeft: "auto", fontSize: "13px", color: "#BFBFBF", whiteSpace: "nowrap" }}
+                title="Maximum percentage above the current lowest price you're willing to pay. Higher values increase the chance of fulfilling the order, but cost more.">
+            Overprice: <input type="number" value={this.state.overpricePercent}
+                              onChange={this.onOverpriceChanged}
+                              min={0}
+                              style={{
+                                backgroundColor: "rgba(0,0,0,0.2)",
+                                border: "1px solid #000",
+                                boxShadow: "1px 1px 0 0 rgba(91,132,181,0.2)",
+                                color: "#BFBFBF",
+                                fontSize: "13px",
+                                width: "50px",
+                                textAlign: "center"
+                              }} />%
+          </span>
+        </div>
         <div className={"profile_customization_block"}>
           <div className="customtext_showcase">
             {pagination}
@@ -98,6 +124,7 @@ export default class Badges extends React.Component<BadgesProperties, BadgesStat
       .map(steamBadgePrice => {
         return (
           <Badge steamId={this.props.steamId} appId={steamBadgePrice.appId} appName={steamBadgePrice.appName}
+                 overpricePercent={this.state.overpricePercent}
                  key={`${steamBadgePrice.appId}-${steamBadgePrice.appName}`} />
         );
       });


### PR DESCRIPTION
- Introduced a configurable "overpricePercent" to customize max overprice.
- Updated UI to allow users to set "overpricePercent" dynamically.
- Modified pricing calculations and API calls to respect the new setting.
- Incremented version to 1.1.3.